### PR TITLE
Fix DHCP messages with included END option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains Rider working folder
+.idea

--- a/Source/Singulink.Net.Dhcp/DhcpOptionCollection.cs
+++ b/Source/Singulink.Net.Dhcp/DhcpOptionCollection.cs
@@ -156,6 +156,8 @@ namespace Singulink.Net.Dhcp
                 stream.WriteByte((byte)pair.Value.Length);
                 stream.Write(pair.Value, 0, pair.Value.Length);
             }
+
+            stream.WriteByte((byte)DhcpOption.End);
         }
     }
 }


### PR DESCRIPTION
Hi,
we are using your dhcp server library for a promile usecase with our ECG devices.
When used with android/apple phones or with windows wifi, your dhcp server worked.
But when we tried to use it with our ECG device (linux based minimalistic OS), it reported Discover and Offer, but the ECG didn't respond with Request.
After digging in wireshark if the DHCP protocol is correctly used, we found it was not.
Here is the packet from wireshark of your DHCP Offer:
![image](https://user-images.githubusercontent.com/6567287/159497515-0115e891-097b-48ea-945a-77b76e22f30f.png)
Here is the packet from wireshark of our internal wifi company DHCP Offer:
![image](https://user-images.githubusercontent.com/6567287/159497659-8d97cfe7-1229-446a-9b45-6ef82dbe9085.png)
As you can see, your DHCP server doesn't include "END" option at the end of options. So I added it to your code after writing all dictionary pairs.